### PR TITLE
Speed up `check.py` by batching and parallelizing candidate probes

### DIFF
--- a/check.py
+++ b/check.py
@@ -9,6 +9,7 @@ import time
 import subprocess
 import ipaddress
 import ctypes
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 # Настройки путей
@@ -45,6 +46,8 @@ DEFAULT_MOBILE_USER_AGENTS = [
     "okhttp/4.12.0 v2rayNG/1.12.28",
 ]
 DEFAULT_PROBE_PATHS = ["/", "/generate_204", "/favicon.ico"]
+CHECK_WORKERS = 8
+CHECK_BATCH_SIZE = 48
 
 # Подключаем новую библиотеку
 go_lib = None
@@ -298,9 +301,6 @@ def get_country_code(host, cache):
 
     # 3. ЗАПРОС К API: Только если IP новый
     try:
-        # Паузу делаем ТОЛЬКО перед реальным сетевым запросом
-        time.sleep(0.5) 
-        
         clean_ip = ip.replace("[", "").replace("]", "")
         url = f"http://ip-api.com/json/{clean_ip}?fields=status,countryCode"
         
@@ -401,6 +401,29 @@ def l7_multi_probe(link: str, stress_config: dict):
             if between_attempts_sleep > 0:
                 time.sleep(between_attempts_sleep)
     return False, 0
+
+def probe_candidate(base_part: str, link: str, host: str, port: str, stress_config: dict, countries_cache: dict):
+    """Проверка кандидата в worker-потоке: L7 + страна."""
+    is_alive, current_latency = l7_multi_probe(link, stress_config)
+    if not is_alive:
+        return {
+            "base": base_part,
+            "host": host,
+            "port": port,
+            "alive": False,
+            "latency": 0,
+            "country": "Unknown",
+        }
+
+    country = get_country_code(host, countries_cache)
+    return {
+        "base": base_part,
+        "host": host,
+        "port": port,
+        "alive": True,
+        "latency": int(current_latency),
+        "country": country,
+    }
 
 def main():
     import subprocess
@@ -554,7 +577,8 @@ def main():
                     stress_config["probe_paths"] = [str(x) for x in data["probe_paths"] if str(x).strip()]
         except: pass
 
-    print(f"📡 Начинаю добор до 200. В очереди: {len(check_queue)}")
+    workers = max(1, int(os.getenv("CHECK_WORKERS", str(CHECK_WORKERS))))
+    print(f"📡 Начинаю добор до 200. В очереди: {len(check_queue)}. workers={workers}")
 
     # --- [ШАГ 4: ЦИКЛ ПРОВЕРКИ] ---
     while len(working_for_sub) < 200 and idx < len(check_queue):
@@ -562,75 +586,97 @@ def main():
             print("🛑 Лимит проверок исчерпан")
             break
 
-        link = check_queue[idx]
-        idx += 1
-        
-        if is_sni_suspicious(link):
-            continue
-            
-        clean_link = link.strip()
-        base_part = clean_link.split("#", 1)[0].strip()
+        remaining_checks = MAX_TO_CHECK - checked_today
+        batch_limit = min(CHECK_BATCH_SIZE, remaining_checks)
+        to_probe = []
 
-        if base_part in seen_parts:
-            continue
-        
-        # Основные фильтры формата
-        if not re.search(r'[a-f0-9\-]{36}@', base_part):
-            continue
-
-        endpoint, host, port = extract_host_port(base_part)
-        if not endpoint or not host or not port:
-            continue
-
-        if is_ipv6(host):
-            add_to_blacklist(base_part)
-            remove_from_input_file(base_part)
-            continue
-
-        # --- ТВОЯ ПРОВЕРКА L7 ---
-        print(f"🔍 Тестирую: {host}:{port}...", end=" ", flush=True)
-        is_alive, current_latency = l7_multi_probe(link, stress_config)
-
-        checked_today += 1
-        resolved_ip = host
-        remove_from_input_file(base_part)
-
-        # Логика лимита IP (5 конфигов на 1 IP)
-        if is_alive:
-            ip_counts[resolved_ip] = ip_counts.get(resolved_ip, 0) + 1
-            if ip_counts[resolved_ip] > 5:
-                print(f"♻️ Скип IP {resolved_ip} (лимит)")
-                continue
-            
-            # Фильтр страны
-            country = get_country_code(host, countries_cache)
-            if country not in ALLOWED_COUNTRIES:
-                print(f"🌍 Мимо ({country})")
+        while len(to_probe) < batch_limit and idx < len(check_queue):
+            link = check_queue[idx]
+            idx += 1
+            if is_sni_suspicious(link):
                 continue
 
-            # Добавляем в списки
-            working_for_base.append(base_part)
-            seen_parts.add(base_part)
-            
-            sub_link = base_part
-            if "sni=" not in sub_link.lower() and not is_ipv6(host):
-                sep = "&" if "?" in sub_link else "?"
-                sub_link += f"{sep}sni={host}"
-            
-            ping_label = f"{current_latency}ms"
-            final_link = rebuild_link_name(sub_link, f"mob {counter} [{ping_label}]")
-            working_for_sub.append(final_link)
-            
-            print(f"✅ ОК {len(working_for_sub)}/200 ({country}): {current_latency}ms")
-            counter += 1
-        else:
-            print(f"💀 Мертв")
-            if base_part in ranking_db:
-                del ranking_db[base_part]
-            fail_time = history.get(base_part, now)
-            if now - fail_time > 86400:
-                with open(BLACKLIST_FILE, 'a') as bl:
-                    bl.write(base_part + "\n")
+            clean_link = link.strip()
+            base_part = clean_link.split("#", 1)[0].strip()
+            if base_part in seen_parts:
+                continue
+            if not re.search(r'[a-f0-9\-]{36}@', base_part):
+                continue
+
+            endpoint, host, port = extract_host_port(base_part)
+            if not endpoint or not host or not port:
+                continue
+            if is_ipv6(host):
+                blacklist.add(base_part)
+                continue
+
+            to_probe.append((base_part, clean_link, host, port))
+
+        if not to_probe:
+            continue
+
+        print(f"⚙️ Батч проверки: {len(to_probe)}")
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_map = {
+                executor.submit(probe_candidate, base_part, clean_link, host, port, stress_config, countries_cache): (base_part, clean_link, host, port)
+                for base_part, clean_link, host, port in to_probe
+            }
+
+            for future in as_completed(future_map):
+                if len(working_for_sub) >= 200:
+                    break
+                if checked_today >= MAX_TO_CHECK:
+                    break
+
+                base_part, clean_link, host, port = future_map[future]
+                checked_today += 1
+                try:
+                    result = future.result()
+                except Exception as e:
+                    print(f"💥 Ошибка worker {host}:{port} — {e}")
+                    result = {
+                        "base": base_part,
+                        "host": host,
+                        "port": port,
+                        "alive": False,
+                        "latency": 0,
+                        "country": "Unknown",
+                    }
+
+                if not result["alive"]:
+                    print(f"💀 Мертв: {host}:{port}")
+                    if base_part in ranking_db:
+                        del ranking_db[base_part]
+                    fail_time = history.get(base_part, now)
+                    if now - fail_time > 86400:
+                        blacklist.add(base_part)
+                    continue
+
+                resolved_ip = host
+                ip_counts[resolved_ip] = ip_counts.get(resolved_ip, 0) + 1
+                if ip_counts[resolved_ip] > 5:
+                    print(f"♻️ Скип IP {resolved_ip} (лимит)")
+                    continue
+
+                country = result["country"]
+                if country not in ALLOWED_COUNTRIES:
+                    print(f"🌍 Мимо ({country}): {host}:{port}")
+                    continue
+
+                current_latency = int(result["latency"])
+                working_for_base.append(base_part)
+                seen_parts.add(base_part)
+
+                sub_link = base_part
+                if "sni=" not in sub_link.lower() and not is_ipv6(host):
+                    sep = "&" if "?" in sub_link else "?"
+                    sub_link += f"{sep}sni={host}"
+
+                ping_label = f"{current_latency}ms"
+                final_link = rebuild_link_name(sub_link, f"mob {counter} [{ping_label}]")
+                working_for_sub.append(final_link)
+                print(f"✅ ОК {len(working_for_sub)}/200 ({country}): {host}:{port} {current_latency}ms")
+                counter += 1
 
     # --- [ШАГ 5: ФИНАЛЬНОЕ СОХРАНЕНИЕ] ---
     
@@ -651,6 +697,12 @@ def main():
 
     with open(RANKING_FILE, "w", encoding="utf-8") as f:
         json.dump(ranking_db, f, ensure_ascii=False, indent=4)
+
+    with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(countries_cache, f, ensure_ascii=False, indent=2)
+
+    with open(BLACKLIST_FILE, "w", encoding="utf-8") as f:
+        f.write("\n".join(sorted(blacklist)))
 
     print(f"🏁 Завершено. Подписка: {len(working_for_sub)}, Очередь: {len(new_deferred)}")
 


### PR DESCRIPTION
### Motivation
- The probe loop was running many network and IO-bound operations serially which made runs very slow and prone to timeouts/cancellations.
- Country lookups and per-candidate file writes added unnecessary serial waits inside the hot loop.
- The goal is to reduce overall wall-time by moving blocking work into workers and minimizing repeated file I/O.

### Description
- Add batching and worker pool controls via `CHECK_WORKERS` and `CHECK_BATCH_SIZE` and use `ThreadPoolExecutor` + `as_completed` to probe candidates in parallel instead of one-by-one.
- Extract heavy per-candidate logic into `probe_candidate` which runs L7 checks (`l7_multi_probe`) and country resolution in worker threads.
- Remove the artificial `time.sleep(0.5)` before country API calls in `get_country_code` to avoid added per-IP delay and cache country responses in `countries_cache`.
- Stop doing per-candidate file writes during probing and switch to in-memory `blacklist`/`countries_cache` accumulation, persisting `countries_cache`, `blacklist`, `ranking.json`, deferred queue and `1.txt` once at the end of the run.

### Testing
- Ran `python -m py_compile check.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e31e43cc832b998df5afb07bbc98)