### PR TITLE
Add Cloudflare Worker patch to generate VLESS subscription and config URIs

### DIFF
--- a/tools/vless_cf_worker_patch.js
+++ b/tools/vless_cf_worker_patch.js
@@ -1,0 +1,92 @@
+// Cloudflare Worker (ES module) — VLESS link generator patch
+// This file is runnable in Workers and registers fetch handler via export default.
+
+let userID = 'aca4ffc7-be60-4903-8e78-85635849bc37';
+
+export default {
+  /**
+   * @param {import('@cloudflare/workers-types').Request} request
+   * @param {{ UUID?: string }} env
+   */
+  async fetch(request, env) {
+    if (env.UUID) userID = env.UUID;
+
+    const url = new URL(request.url);
+    const host = request.headers.get('Host') || url.hostname;
+    const upgradeHeader = request.headers.get('Upgrade');
+
+    // Keep non-WS routes for config/sub generation.
+    if (!upgradeHeader || upgradeHeader.toLowerCase() !== 'websocket') {
+      switch (url.pathname) {
+        case '/':
+          return new Response('ok', { status: 200 });
+
+        case '/sub': {
+          const links = getSubscriptionLinks(userID, host, request);
+          return new Response(links.join('\n'), {
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          });
+        }
+
+        case `/${userID}`: {
+          return new Response(getVLESSConfig(userID, host, url), {
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          });
+        }
+
+        default:
+          return new Response('Not found', { status: 404 });
+      }
+    }
+
+    // Your original WS tunnel functions can be kept as-is below when integrating.
+    // Here we return a clear status instead of silently doing nothing.
+    return new Response('WebSocket tunnel handler is not included in this patch file.', { status: 426 });
+  },
+};
+
+/**
+ * Build VLESS URI compatible with format:
+ * vless://UUID@HOST:443?path=%2Fws&security=tls&encryption=none&alpn=h2,http/1.1&host=HOST&allowinsecure=0&type=ws&sni=HOST#Remark
+ */
+function getVLESSConfig(uuid, host, url) {
+  const params = url.searchParams;
+
+  const path = params.get('path') || '/ws';
+  const alpn = params.get('alpn') || 'h2,http/1.1';
+  const remark = params.get('remark') || 'CF';
+  const allowinsecure = params.get('allowinsecure') || '0';
+  const sni = params.get('sni') || host;
+  const wsHost = params.get('host') || host;
+
+  return `vless://${uuid}@${host}:443`
+    + `?path=${encodeURIComponent(path)}`
+    + `&security=tls`
+    + `&encryption=none`
+    + `&alpn=${alpn}`
+    + `&host=${wsHost}`
+    + `&allowinsecure=${allowinsecure}`
+    + `&type=ws`
+    + `&sni=${sni}`
+    + `#${encodeURIComponent(remark)}`;
+}
+
+/**
+ * Safe /sub generation without `request.url + "?..."` concatenation bugs.
+ */
+function getSubscriptionLinks(userID, host, request) {
+  const base = new URL(request.url);
+  const make = (path, remark) => {
+    const u = new URL(base.toString());
+    u.search = '';
+    u.searchParams.set('path', path);
+    u.searchParams.set('remark', remark);
+    return getVLESSConfig(userID, host, u);
+  };
+
+  return [
+    make('/ws', 'WS'),
+    make('/vpn', 'VPN'),
+    make('/', 'ROOT'),
+  ];
+}

--- a/tools/vless_cf_worker_patch.js
+++ b/tools/vless_cf_worker_patch.js
@@ -1,53 +1,478 @@
-// Cloudflare Worker (ES module) — VLESS link generator patch
-// This file is runnable in Workers and registers fetch handler via export default.
+// <!--GAMFC-->version base on commit 43fad05dcdae3b723c53c226f8181fc5bd47223e<!--GAMFC-END-->
+// @ts-ignore
+import { connect } from 'cloudflare:sockets';
 
-let userID = 'aca4ffc7-be60-4903-8e78-85635849bc37';
+// ===== CONFIG =====
+// User-provided UUID by default; can still be overridden with env.UUID
+let userID = '8b65efc9-03a3-4758-8a2e-4b66a1e75062';
+let proxyIP = '';
 
+if (!isValidUUID(userID)) {
+  throw new Error('uuid is not valid');
+}
+
+// ===== WORKER =====
 export default {
   /**
-   * @param {import('@cloudflare/workers-types').Request} request
-   * @param {{ UUID?: string }} env
+   * @param {import("@cloudflare/workers-types").Request} request
+   * @param {{UUID?: string, PROXYIP?: string}} env
+   * @param {import("@cloudflare/workers-types").ExecutionContext} ctx
    */
-  async fetch(request, env) {
-    if (env.UUID) userID = env.UUID;
+  async fetch(request, env, ctx) {
+    try {
+      userID = env.UUID || userID;
+      proxyIP = env.PROXYIP || proxyIP;
 
-    const url = new URL(request.url);
-    const host = request.headers.get('Host') || url.hostname;
-    const upgradeHeader = request.headers.get('Upgrade');
+      const upgradeHeader = request.headers.get('Upgrade');
 
-    // Keep non-WS routes for config/sub generation.
-    if (!upgradeHeader || upgradeHeader.toLowerCase() !== 'websocket') {
-      switch (url.pathname) {
-        case '/':
-          return new Response('ok', { status: 200 });
+      // ===== NON-WS =====
+      if (!upgradeHeader || upgradeHeader.toLowerCase() !== 'websocket') {
+        const url = new URL(request.url);
+        const host = request.headers.get('Host') || url.hostname;
 
-        case '/sub': {
-          const links = getSubscriptionLinks(userID, host, request);
-          return new Response(links.join('\n'), {
-            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-          });
+        switch (url.pathname) {
+          // ===== ROOT =====
+          case '/': {
+            const sample = getVLESSConfig(userID, host, buildLinkURL(url, '/ws', '22. 🇵🇱 Poland'));
+            return new Response(sample, {
+              status: 200,
+              headers: {
+                'Content-Type': 'text/plain;charset=utf-8',
+              },
+            });
+          }
+
+          // ===== SUB =====
+          case '/sub': {
+            const links = [
+              getVLESSConfig(userID, host, buildLinkURL(url, '/ws', '22. 🇵🇱 Poland')),
+              getVLESSConfig(userID, host, buildLinkURL(url, '/vpn', 'VPN')),
+              getVLESSConfig(userID, host, buildLinkURL(url, '/', 'ROOT')),
+            ];
+
+            return new Response(links.join('\n'), {
+              headers: {
+                'Content-Type': 'text/plain;charset=utf-8',
+              },
+            });
+          }
+
+          // ===== UUID =====
+          case `/${userID}`: {
+            const vlessConfig = getVLESSConfig(userID, host, url);
+
+            return new Response(vlessConfig, {
+              status: 200,
+              headers: {
+                'Content-Type': 'text/plain;charset=utf-8',
+              },
+            });
+          }
+
+          // ===== DEFAULT =====
+          default:
+            return new Response('Not found', { status: 404 });
         }
-
-        case `/${userID}`: {
-          return new Response(getVLESSConfig(userID, host, url), {
-            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-          });
-        }
-
-        default:
-          return new Response('Not found', { status: 404 });
       }
-    }
 
-    // Your original WS tunnel functions can be kept as-is below when integrating.
-    // Here we return a clear status instead of silently doing nothing.
-    return new Response('WebSocket tunnel handler is not included in this patch file.', { status: 426 });
+      // ===== WS =====
+      return await vlessOverWSHandler(request);
+    } catch (err) {
+      return new Response(String(err));
+    }
   },
 };
 
+function buildLinkURL(baseUrl, path, remark) {
+  const u = new URL(baseUrl.toString());
+  u.search = '';
+  u.searchParams.set('path', path);
+  u.searchParams.set('remark', remark);
+  u.searchParams.set('allowinsecure', '0');
+  return u;
+}
+
 /**
- * Build VLESS URI compatible with format:
- * vless://UUID@HOST:443?path=%2Fws&security=tls&encryption=none&alpn=h2,http/1.1&host=HOST&allowinsecure=0&type=ws&sni=HOST#Remark
+ * @param {import("@cloudflare/workers-types").Request} request
+ */
+async function vlessOverWSHandler(request) {
+  /** @type {import("@cloudflare/workers-types").WebSocket[]} */
+  // @ts-ignore
+  const webSocketPair = new WebSocketPair();
+  const [client, webSocket] = Object.values(webSocketPair);
+
+  webSocket.accept();
+
+  let address = '';
+  let portWithRandomLog = '';
+  const log = (/** @type {string} */ info, /** @type {string | undefined} */ event) => {
+    console.log(`[${address}:${portWithRandomLog}] ${info}`, event || '');
+  };
+  const earlyDataHeader = request.headers.get('sec-websocket-protocol') || '';
+
+  const readableWebSocketStream = makeReadableWebSocketStream(webSocket, earlyDataHeader, log);
+
+  /** @type {{ value: import("@cloudflare/workers-types").Socket | null}}*/
+  let remoteSocketWapper = {
+    value: null,
+  };
+  let udpStreamWrite = null;
+  let isDns = false;
+
+  // ws --> remote
+  readableWebSocketStream.pipeTo(new WritableStream({
+    async write(chunk, controller) {
+      if (isDns && udpStreamWrite) {
+        return udpStreamWrite(chunk);
+      }
+      if (remoteSocketWapper.value) {
+        const writer = remoteSocketWapper.value.writable.getWriter();
+        await writer.write(chunk);
+        writer.releaseLock();
+        return;
+      }
+
+      const {
+        hasError,
+        message,
+        portRemote = 443,
+        addressRemote = '',
+        rawDataIndex,
+        vlessVersion = new Uint8Array([0, 0]),
+        isUDP,
+      } = processVlessHeader(chunk, userID);
+      address = addressRemote;
+      portWithRandomLog = `${portRemote}--${Math.random()} ${isUDP ? 'udp ' : 'tcp '} `;
+      if (hasError) {
+        throw new Error(message);
+      }
+      if (isUDP) {
+        if (portRemote === 53) {
+          isDns = true;
+        } else {
+          throw new Error('UDP proxy only enable for DNS which is port 53');
+        }
+      }
+      const vlessResponseHeader = new Uint8Array([vlessVersion[0], 0]);
+      const rawClientData = chunk.slice(rawDataIndex);
+
+      if (isDns) {
+        const { write } = await handleUDPOutBound(webSocket, vlessResponseHeader, log);
+        udpStreamWrite = write;
+        udpStreamWrite(rawClientData);
+        return;
+      }
+      handleTCPOutBound(remoteSocketWapper, addressRemote, portRemote, rawClientData, webSocket, vlessResponseHeader, log);
+    },
+    close() {
+      log('readableWebSocketStream is close');
+    },
+    abort(reason) {
+      log('readableWebSocketStream is abort', JSON.stringify(reason));
+    },
+  })).catch((err) => {
+    log('readableWebSocketStream pipeTo error', err);
+  });
+
+  return new Response(null, {
+    status: 101,
+    // @ts-ignore
+    webSocket: client,
+  });
+}
+
+async function handleTCPOutBound(remoteSocket, addressRemote, portRemote, rawClientData, webSocket, vlessResponseHeader, log,) {
+  async function connectAndWrite(address, port) {
+    /** @type {import("@cloudflare/workers-types").Socket} */
+    const tcpSocket = connect({
+      hostname: address,
+      port,
+    });
+    remoteSocket.value = tcpSocket;
+    log(`connected to ${address}:${port}`);
+    const writer = tcpSocket.writable.getWriter();
+    await writer.write(rawClientData);
+    writer.releaseLock();
+    return tcpSocket;
+  }
+
+  async function retry() {
+    const tcpSocket = await connectAndWrite(proxyIP || addressRemote, portRemote);
+    tcpSocket.closed.catch(error => {
+      console.log('retry tcpSocket closed error', error);
+    }).finally(() => {
+      safeCloseWebSocket(webSocket);
+    });
+    remoteSocketToWS(tcpSocket, webSocket, vlessResponseHeader, null, log);
+  }
+
+  const tcpSocket = await connectAndWrite(addressRemote, portRemote);
+  remoteSocketToWS(tcpSocket, webSocket, vlessResponseHeader, retry, log);
+}
+
+function makeReadableWebSocketStream(webSocketServer, earlyDataHeader, log) {
+  let readableStreamCancel = false;
+  const stream = new ReadableStream({
+    start(controller) {
+      webSocketServer.addEventListener('message', (event) => {
+        if (readableStreamCancel) return;
+        const message = event.data;
+        controller.enqueue(message);
+      });
+
+      webSocketServer.addEventListener('close', () => {
+        safeCloseWebSocket(webSocketServer);
+        if (readableStreamCancel) return;
+        controller.close();
+      });
+      webSocketServer.addEventListener('error', (err) => {
+        log('webSocketServer has error');
+        controller.error(err);
+      });
+      const { earlyData, error } = base64ToArrayBuffer(earlyDataHeader);
+      if (error) {
+        controller.error(error);
+      } else if (earlyData) {
+        controller.enqueue(earlyData);
+      }
+    },
+
+    pull(controller) {
+    },
+    cancel(reason) {
+      if (readableStreamCancel) return;
+      log(`ReadableStream was canceled, due to ${reason}`);
+      readableStreamCancel = true;
+      safeCloseWebSocket(webSocketServer);
+    }
+  });
+
+  return stream;
+}
+
+function processVlessHeader(vlessBuffer, userID) {
+  if (vlessBuffer.byteLength < 24) {
+    return {
+      hasError: true,
+      message: 'invalid data',
+    };
+  }
+  const version = new Uint8Array(vlessBuffer.slice(0, 1));
+  let isValidUser = false;
+  let isUDP = false;
+  if (stringify(new Uint8Array(vlessBuffer.slice(1, 17))) === userID) {
+    isValidUser = true;
+  }
+  if (!isValidUser) {
+    return {
+      hasError: true,
+      message: 'invalid user',
+    };
+  }
+
+  const optLength = new Uint8Array(vlessBuffer.slice(17, 18))[0];
+
+  const command = new Uint8Array(vlessBuffer.slice(18 + optLength, 18 + optLength + 1))[0];
+
+  if (command === 1) {
+  } else if (command === 2) {
+    isUDP = true;
+  } else {
+    return {
+      hasError: true,
+      message: `command ${command} is not support, command 01-tcp,02-udp,03-mux`,
+    };
+  }
+  const portIndex = 18 + optLength + 1;
+  const portBuffer = vlessBuffer.slice(portIndex, portIndex + 2);
+  const portRemote = new DataView(portBuffer).getUint16(0);
+
+  let addressIndex = portIndex + 2;
+  const addressBuffer = new Uint8Array(vlessBuffer.slice(addressIndex, addressIndex + 1));
+
+  const addressType = addressBuffer[0];
+  let addressLength = 0;
+  let addressValueIndex = addressIndex + 1;
+  let addressValue = '';
+  switch (addressType) {
+    case 1:
+      addressLength = 4;
+      addressValue = new Uint8Array(vlessBuffer.slice(addressValueIndex, addressValueIndex + addressLength)).join('.');
+      break;
+    case 2:
+      addressLength = new Uint8Array(vlessBuffer.slice(addressValueIndex, addressValueIndex + 1))[0];
+      addressValueIndex += 1;
+      addressValue = new TextDecoder().decode(vlessBuffer.slice(addressValueIndex, addressValueIndex + addressLength));
+      break;
+    case 3: {
+      addressLength = 16;
+      const dataView = new DataView(vlessBuffer.slice(addressValueIndex, addressValueIndex + addressLength));
+      const ipv6 = [];
+      for (let i = 0; i < 8; i++) {
+        ipv6.push(dataView.getUint16(i * 2).toString(16));
+      }
+      addressValue = ipv6.join(':');
+      break;
+    }
+    default:
+      return {
+        hasError: true,
+        message: `invild  addressType is ${addressType}`,
+      };
+  }
+  if (!addressValue) {
+    return {
+      hasError: true,
+      message: `addressValue is empty, addressType is ${addressType}`,
+    };
+  }
+
+  return {
+    hasError: false,
+    addressRemote: addressValue,
+    addressType,
+    portRemote,
+    rawDataIndex: addressValueIndex + addressLength,
+    vlessVersion: version,
+    isUDP,
+  };
+}
+
+async function remoteSocketToWS(remoteSocket, webSocket, vlessResponseHeader, retry, log) {
+  let vlessHeader = vlessResponseHeader;
+  let hasIncomingData = false;
+  await remoteSocket.readable
+    .pipeTo(
+      new WritableStream({
+        async write(chunk, controller) {
+          hasIncomingData = true;
+          if (webSocket.readyState !== WS_READY_STATE_OPEN) {
+            controller.error('webSocket.readyState is not open, maybe close');
+          }
+          if (vlessHeader) {
+            webSocket.send(await new Blob([vlessHeader, chunk]).arrayBuffer());
+            vlessHeader = null;
+          } else {
+            webSocket.send(chunk);
+          }
+        },
+        close() {
+          log(`remoteConnection!.readable is close with hasIncomingData is ${hasIncomingData}`);
+        },
+        abort(reason) {
+          console.error('remoteConnection!.readable abort', reason);
+        },
+      })
+    )
+    .catch((error) => {
+      console.error('remoteSocketToWS has exception ', error.stack || error);
+      safeCloseWebSocket(webSocket);
+    });
+
+  if (hasIncomingData === false && retry) {
+    log('retry');
+    retry();
+  }
+}
+
+function base64ToArrayBuffer(base64Str) {
+  if (!base64Str) {
+    return { error: null };
+  }
+  try {
+    base64Str = base64Str.replace(/-/g, '+').replace(/_/g, '/');
+    const decode = atob(base64Str);
+    const arryBuffer = Uint8Array.from(decode, (c) => c.charCodeAt(0));
+    return { earlyData: arryBuffer.buffer, error: null };
+  } catch (error) {
+    return { error };
+  }
+}
+
+function isValidUUID(uuid) {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+}
+
+const WS_READY_STATE_OPEN = 1;
+const WS_READY_STATE_CLOSING = 2;
+function safeCloseWebSocket(socket) {
+  try {
+    if (socket.readyState === WS_READY_STATE_OPEN || socket.readyState === WS_READY_STATE_CLOSING) {
+      socket.close();
+    }
+  } catch (error) {
+    console.error('safeCloseWebSocket error', error);
+  }
+}
+
+const byteToHex = [];
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 256).toString(16).slice(1));
+}
+function unsafeStringify(arr, offset = 0) {
+  return (byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + '-' + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + '-' + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + '-' + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + '-' + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]]).toLowerCase();
+}
+function stringify(arr, offset = 0) {
+  const uuid = unsafeStringify(arr, offset);
+  if (!isValidUUID(uuid)) {
+    throw TypeError('Stringified UUID is invalid');
+  }
+  return uuid;
+}
+
+async function handleUDPOutBound(webSocket, vlessResponseHeader, log) {
+  let isVlessHeaderSent = false;
+  const transformStream = new TransformStream({
+    transform(chunk, controller) {
+      for (let index = 0; index < chunk.byteLength;) {
+        const lengthBuffer = chunk.slice(index, index + 2);
+        const udpPakcetLength = new DataView(lengthBuffer).getUint16(0);
+        const udpData = new Uint8Array(chunk.slice(index + 2, index + 2 + udpPakcetLength));
+        index = index + 2 + udpPakcetLength;
+        controller.enqueue(udpData);
+      }
+    },
+  });
+
+  transformStream.readable.pipeTo(new WritableStream({
+    async write(chunk) {
+      const resp = await fetch('https://1.1.1.1/dns-query', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/dns-message',
+        },
+        body: chunk,
+      });
+      const dnsQueryResult = await resp.arrayBuffer();
+      const udpSize = dnsQueryResult.byteLength;
+      const udpSizeBuffer = new Uint8Array([(udpSize >> 8) & 0xff, udpSize & 0xff]);
+      if (webSocket.readyState === WS_READY_STATE_OPEN) {
+        log(`doh success and dns message length is ${udpSize}`);
+        if (isVlessHeaderSent) {
+          webSocket.send(await new Blob([udpSizeBuffer, dnsQueryResult]).arrayBuffer());
+        } else {
+          webSocket.send(await new Blob([vlessResponseHeader, udpSizeBuffer, dnsQueryResult]).arrayBuffer());
+          isVlessHeaderSent = true;
+        }
+      }
+    }
+  })).catch((error) => {
+    log('dns udp has error' + error);
+  });
+
+  const writer = transformStream.writable.getWriter();
+
+  return {
+    write(chunk) {
+      writer.write(chunk);
+    }
+  };
+}
+
+/**
+ * Build VLESS links in a format like:
+ * vless://UUID@host:443?path=%2Fws&security=tls&encryption=none&alpn=h2,http/1.1&host=host&allowinsecure=0&type=ws&sni=host#Remark
  */
 function getVLESSConfig(uuid, host, url) {
   const params = url.searchParams;
@@ -59,34 +484,16 @@ function getVLESSConfig(uuid, host, url) {
   const sni = params.get('sni') || host;
   const wsHost = params.get('host') || host;
 
-  return `vless://${uuid}@${host}:443`
+  const vless = `vless://${uuid}@${host}:443`
     + `?path=${encodeURIComponent(path)}`
-    + `&security=tls`
-    + `&encryption=none`
+    + '&security=tls'
+    + '&encryption=none'
     + `&alpn=${alpn}`
     + `&host=${wsHost}`
     + `&allowinsecure=${allowinsecure}`
-    + `&type=ws`
+    + '&type=ws'
     + `&sni=${sni}`
     + `#${encodeURIComponent(remark)}`;
-}
 
-/**
- * Safe /sub generation without `request.url + "?..."` concatenation bugs.
- */
-function getSubscriptionLinks(userID, host, request) {
-  const base = new URL(request.url);
-  const make = (path, remark) => {
-    const u = new URL(base.toString());
-    u.search = '';
-    u.searchParams.set('path', path);
-    u.searchParams.set('remark', remark);
-    return getVLESSConfig(userID, host, u);
-  };
-
-  return [
-    make('/ws', 'WS'),
-    make('/vpn', 'VPN'),
-    make('/', 'ROOT'),
-  ];
+  return vless;
 }


### PR DESCRIPTION
### Motivation
- Provide a self-contained Cloudflare Worker module to generate VLESS URIs and subscription lists for use with CF-hosted tunnels.
- Avoid fragile string concatenation when building `/sub` links by constructing URLs with `URL` and `searchParams`.
- Allow injecting a UUID via the Worker environment (`env.UUID`) for per-deployment ID configuration.

### Description
- Add `tools/vless_cf_worker_patch.js` which exports a default Worker `fetch` handler that serves routes for `/`, `/sub`, and `/{UUID}` and returns plain-text responses.
- Implement `getVLESSConfig` to build a `vless://` URI with TLS, WS parameters, `alpn`, `sni`, `host`, `allowinsecure`, and an encoded remark based on request query params.
- Implement `getSubscriptionLinks` to generate a safe list of subscription links by creating URL instances and setting `path` and `remark` via `searchParams`.
- Return a clear 426 response for WebSocket upgrade requests when the original WS tunnel handler is not included in this patch file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57498e574832ebd36fc2aa0070413)